### PR TITLE
Fix triggering the endedTrackingWith delegate method before handling snap

### DIFF
--- a/MSCircularSlider/MSCircularSlider.swift
+++ b/MSCircularSlider/MSCircularSlider.swift
@@ -565,8 +565,8 @@ public class MSCircularSlider: UIControl {
     override public func endTracking(_ touch: UITouch?, with event: UIEvent?) {
         super.endTracking(touch, with: event)
         
-        castDelegate?.circularSlider(self, endedTrackingWith: currentValue)
         snapHandle()
+        castDelegate?.circularSlider(self, endedTrackingWith: currentValue)
         
         handle.isPressed = false
         isSliding = false


### PR DESCRIPTION
This avoids the delegate to send a value that isn't the currentValue after the `snapHandle`.
This is critical for me because I use another label to show the value.