### PR TITLE
Endy/Fix slider working even when the initial touch is not on the slider

### DIFF
--- a/MSCircularSlider/MSCircularSlider.swift
+++ b/MSCircularSlider/MSCircularSlider.swift
@@ -491,7 +491,7 @@ public class MSCircularSlider: UIControl {
             return true
         }
         
-        return pointInsideCircle(location)
+        return false    //pointInsideCircle(location)
     }
     
     override public func continueTracking(_ touch: UITouch, with event: UIEvent?) -> Bool {


### PR DESCRIPTION
Solution for the issue https://github.com/ThunderStruct/MSCircularSlider/issues/18 proposed by MoonshineSG