### PR TITLE
Fix initial value when minimumValue is not 0

### DIFF
--- a/MSCircularSlider/MSCircularSlider.swift
+++ b/MSCircularSlider/MSCircularSlider.swift
@@ -888,12 +888,12 @@ public class MSCircularSlider: UIControl {
     
     /** Calculates the angle from north given a value */
     internal func angleFrom(value: Double) -> CGFloat {
-        return (CGFloat(value) * maximumAngle) / CGFloat(maximumValue - minimumValue)
+        return (CGFloat(value - minimumValue) * maximumAngle) / CGFloat(maximumValue - minimumValue)
     }
     
     /** Calculates the value given an angle from north */
     internal func valueFrom(angle: CGFloat) -> Double {
-        return (maximumValue - minimumValue) * Double(angle) / Double(maximumAngle)
+        return ((maximumValue - minimumValue) * Double(angle) / Double(maximumAngle)) + minimumValue
     }
     
     /** Converts degrees to radians */


### PR DESCRIPTION
In my application, the slider goes from 1 to X, and without these changes the minimum value is always 0, just adding an "offset".
When the maximum value is 100 you can't notice the change, but when the maximum value is 5, it is a huge difference.

With these changes, the angle 0 will be the real minimum value.

Thank you!